### PR TITLE
Bumped top-end version of optparse-applicative to 0.15.

### DIFF
--- a/hasql-optparse-applicative.cabal
+++ b/hasql-optparse-applicative.cabal
@@ -47,6 +47,6 @@ library
     hasql >= 0.19 && < 0.20,
     hasql-pool >= 0.4 && < 0.5,
     -- 
-    optparse-applicative >= 0.12 && < 0.14,
+    optparse-applicative >= 0.12 && < 0.15,
     -- 
     base-prelude < 2

--- a/hasql-optparse-applicative.cabal
+++ b/hasql-optparse-applicative.cabal
@@ -1,7 +1,7 @@
 name:
   hasql-optparse-applicative
 version:
-  0.2.1
+  0.2.2
 synopsis:
   "optparse-applicative" parsers for "hasql"
 category:


### PR DESCRIPTION
Using the latest version of `optparse-applicative` does build against stockage nightly (nightly-2017-09-20).